### PR TITLE
feat: impl documenting exported attrs in modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.9",
  "serde",
 ]
 
@@ -431,8 +431,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -477,7 +477,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.9",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -628,6 +628,15 @@ dependencies = [
  "itertools",
  "malachite-base",
  "malachite-nz",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -900,6 +909,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,8 +937,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1096,6 +1132,7 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-subscriber",
+ "tracing-test",
  "walkdir",
 ]
 
@@ -1304,12 +1341,37 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ pretty_assertions = "1"
 assert_fs         = "1.1.3"
 assert_cmd = "2.0.17"
 dir-diff = "0.3.3"
+tracing-test = "0.2.5"
 
 
 # please tell me what to do Clippy-senpai

--- a/src/render/expr.rs
+++ b/src/render/expr.rs
@@ -100,7 +100,6 @@ pub fn render_expr(expr: Expr) -> String {
             out.push(']');
         }
         Expr::DictComp(expr_dict_comp) => {
-            dbg!(&expr_dict_comp);
             out.push('{');
             out.push_str(&render_expr(*expr_dict_comp.key));
             out.push_str(": ");
@@ -282,7 +281,7 @@ fn render_keyword(keyword: Keyword) -> String {
     out
 }
 
-fn render_constant(constant: Constant) -> String {
+pub(crate) fn render_constant(constant: Constant) -> String {
     match constant {
         Constant::None => String::from("None"),
         Constant::Bool(b) => {

--- a/tests/rendered_full/test_pkg/_private/_index.md
+++ b/tests/rendered_full/test_pkg/_private/_index.md
@@ -3,3 +3,8 @@
 The _private subpackage
 
 This subpackage contains internal modules and functions intended for internal use.
+
+## Exports:
+
+- [calculate_secret_value](#test_pkg._private.calculate_secret_value)
+- [InternalHelper](#test_pkg._private.InternalHelper)

--- a/tests/rendered_full/test_pkg/foo.md
+++ b/tests/rendered_full/test_pkg/foo.md
@@ -4,6 +4,11 @@ foo.py
 
 Example module demonstrating a calculator.
 
+## Exports:
+
+- [add](#test_pkg.foo.add)
+- [multiply](#test_pkg.foo.multiply)
+
 ## test_pkg.foo.add
 
 add(a: float, b: float) -> float

--- a/tests/rendered_no_private/test_pkg/foo.md
+++ b/tests/rendered_no_private/test_pkg/foo.md
@@ -4,6 +4,11 @@ foo.py
 
 Example module demonstrating a calculator.
 
+## Exports:
+
+- [add](#test_pkg.foo.add)
+- [multiply](#test_pkg.foo.multiply)
+
 ## test_pkg.foo.add
 
 add(a: float, b: float) -> float

--- a/tests/test_pkg/foo.py
+++ b/tests/test_pkg/foo.py
@@ -4,6 +4,8 @@ foo.py
 Example module demonstrating a calculator.
 """
 
+__all__ = ["add", "multiply"]
+
 
 def add(a: float, b: float) -> float:
     """


### PR DESCRIPTION
With this PR, the output docs will also document what is added in the `__all__` attribute under the header `## Exports`. This will become much more interesting when we start adding/including submodule contents. How exactly it works might have to be adjusted then. 