### PR TITLE
Fix: rename to snakedown

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+default_install_hook_types: [pre-commit, commit-msg]
 repos:
   - repo: https://github.com/doublify/pre-commit-rust
     rev: v1.0
@@ -23,10 +24,10 @@ repos:
     rev: v1.31.2
     hooks:
       - id: typos
-  - repo: https://github.com/savente93/commitlint-rs
-    rev: d0f10c617d701e29e5fbf153222a4e4120b994fa
+  - repo: https://github.com/crate-ci/committed
+    rev: v1.1.7
     hooks:
-      - id: commitlint
+      - id: committed
   - repo: local
     hooks:
     - id: check-no-dbg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,7 +1112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
-name = "snakeoil"
+name = "snakedown"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name         = "snakeoil"
+name         = "snakedown"
 version      = "0.1.0"
 authors      = ["Sam Vente <savente93@proton.me>"]
 edition      = "2024"
 rust-version = "1.85"
-description  = "A Python api extractor written in Rust"
+description  = "This is a snakedown. Hand over your docs, nice and clean, and nobody gets confused."
 readme       = "README.md"
 license      = "MIT"
 
 
-documentation = "https://docs.rs/snakeoil"
-repository    = "https://github.com/savente93/snakeoil"
+documentation = "https://docs.rs/snakedown"
+repository    = "https://github.com/savente93/snakedown"
 
 
 [lib]
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 
 [[bin]]
 path = "src/main.rs"
-name = "snakeoil"
+name = "snakedown"
 
 
 [dependencies]
@@ -56,9 +56,9 @@ walkdir           = "2.5.0"
 tempfile          = "3.20.0"
 pretty_assertions = "1"
 assert_fs         = "1.1.3"
-assert_cmd = "2.0.17"
-dir-diff = "0.3.3"
-tracing-test = "0.2.5"
+assert_cmd        = "2.0.17"
+dir-diff          = "0.3.3"
+tracing-test      = "0.2.5"
 
 
 # please tell me what to do Clippy-senpai

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# SnakeOil 🐍🧪
+# SnakeDown 🐍🕵️‍♂️
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![codecov](https://codecov.io/gh/savente93/snakeoil/branch/main/graph/badge.svg)](https://codecov.io/gh/savente93/snakeoil)
- 
+[![codecov](https://codecov.io/gh/savente93/SnakeDown/branch/main/graph/badge.svg)](https://codecov.io/gh/savente93/SnakeDown)
+
 
 A Python API extractor written in Rust. I got frustrated with the standard tools used for documentation generation used in Python, namely that all of the ones I've worked with have at least one of the following to characteristics:
 
@@ -13,23 +13,23 @@ Number 1 is particularly a concern for packages that are slow to import, or have
 
 There are many excellent Static Site Generators like [Hugo](https://gohugo.io) or [Zola](https://www.getzola.org) that are fast and offer a much better experience when developing. Typically, documentation are static pages so they should be a perfect fit, except for one issue: automatic API reference generation. This was a big showstopper... until now!
 
-SnakeOil is an experiment to get to a place where using Hugo or Zola for python documentation generation is a viable option.
+SnakeDown is an experiment to get to a place where using Hugo or Zola for python documentation generation is a viable option.
 
 
 (Currently mostly for shits and giggles, but who knows.)
 
 ## Design goals:
 
-While the project might not cover all of these goals yet, these are some of the things I try to keep in mind when working on SnakeOil (in loose order of precedence):
+While the project might not cover all of these goals yet, these are some of the things I try to keep in mind when working on SnakeDown (in loose order of precedence):
 
-1. **Sensible defaults over infinite configurability**. Infinite configuration comes with a lot of complexity both for user and developer, and in my opinion it is not worth it, especially at the stage SnakeOil is at now. I'd rather do 10 things right 80% of the time, then 2 things right 99.999% of the time.
+1. **Sensible defaults over infinite configurability**. Infinite configuration comes with a lot of complexity both for user and developer, and in my opinion it is not worth it, especially at the stage SnakeDown is at now. I'd rather do 10 things right 80% of the time, then 2 things right 99.999% of the time.
 2. **Correctness over speed** While speed is an explicit goal of this project, correctness should take precedent. Doing the wrong thing extremely fast is useless.
 3. **Be fast** We only *parse* the source code to extract the docstrings from it, but we don't actually have to do any execution. While this might mean we can't always fully expand everything, type signatures are constants or names in the vast majority of cases, so this is a decent alternative. This by itself should make us Fast Enough :tm:
 4. **Be fun** This is a personal project for the time being, and I like to have fun with those.
 
 ## Status
 
-Currently, SnakeOil is solidly in the MVP state. While I am quite happy with it so far, you use it at your own risk. That said, I always welcome bug reports and feature requests if you do decide to try it! Below is a loose planning of the features I want to work on
+Currently, SnakeDown is solidly in the MVP state. While I am quite happy with it so far, you use it at your own risk. That said, I always welcome bug reports and feature requests if you do decide to try it! Below is a loose planning of the features I want to work on
 
 
 ## Loose Roadmap:
@@ -38,18 +38,18 @@ Currently, SnakeOil is solidly in the MVP state. While I am quite happy with it 
 - [x] Parse them to extract documentation
 - [x] Dump documentation in similar file structure to original package
 - [x] Fill out the CLI
-- [ ] Test output in SSG
-- [ ] Logging at appropriate levels
+- [ ] Test output in SSGs (zola, hugo for now, please submit a feature request if you want others included)
+- [x] Logging at appropriate levels
 - [ ] Parse/render docstring formats like numpy and google so we can render them better
 - [ ] Configuration file
-- [ ] Support multiple formats?
+- [ ] Support multiple formats? (md, rst)
 - [ ] Do reference linking inside the docs
 - [ ] Do reference linking to external docs
 - [ ] Benchmarking & optimisation
 
 ## FAQ
 
-### Is SnakeOil dead?
+### Is SnakeDown dead?
 
 No. It is a personal project for the time being so while there may be persiods of inactivity, I intend to keep working on it until it serves my personal needs. (Poe's law dictates that I mention this is mostly a joke. It's a common question for FOSS projects that don't have the high velocity of larger projects and this is a tongue in cheek way of beating this question to the punch)
 
@@ -64,16 +64,15 @@ To quote one of the giants in our field BurtnSushi:
 (source: [ripgrep](https://github.com/BurntSushi/ripgrep/blob/94305125ef33b86151b6cd2ce2b33d641f6b6ac3/FAQ.md#release))
 
 
-The same applies to SnakeOil.
+The same applies to SnakeDown.
 
-### Why is it called SnakeOil?
+### Why is it called SnakeDown?
 
-Two main reasons:
+Three main reasons:
 
-1. You are trying to extract things from a snake (python) that may or may not be beneficial (documentation isn't always as helpful as we hope it will be).
-2. I find it funny
-
-So it's not because I am a snake oil salesperson in the colloquial sense.
+1. I was first going to call it "SnakeOil" for extraing things from snakes of dubious value but that name was already taken
+2. it's about shaking down your python code for docs
+3. I find it funny
 
 ### Did people actually ask these questions?
 
@@ -81,7 +80,7 @@ Not yet, but I suspect they will.
 
 
 ## Dev tools
-To develop SnakeOil you'll want to have these tools installed:
+To develop SnakeDown you'll want to have these tools installed:
 
 - [`just`](https://github.com/casey/just) A command runner to run (and document) workflows we run, including installing dev and publish dependencies
 - [`typos-cli`](https://github.com/crate-ci/typos) Fixing typos... not that we make any... but you know, just in case.
@@ -89,7 +88,7 @@ To develop SnakeOil you'll want to have these tools installed:
 - [`bacon`](https://github.com/Canop/bacon) A runner that will watch your files and run checks, tests, linting etc. when they change. Very useful while developing
 
 ##  Publishing Tools
-If you have to publish, or otherwise fiddle with dependencies of SnakeOil you'll want these installed as well:
+If you have to publish, or otherwise fiddle with dependencies of SnakeDown you'll want these installed as well:
 - [`cargo-semver`](https://github.com/obi1kenobi/cargo-semver-checks) A cargo plugin to check that we haven't accidentally broken our API when we didn't mean to.
 - [`cargo-edit`](https://github.com/killercup/cargo-edit) A cargo plugin for managing dependencies, incl updating them.
 - [`git-cliff`](https://github.com/orhun/git-cliff) A neat tool to generate our changelog

--- a/cliff.toml
+++ b/cliff.toml
@@ -35,7 +35,7 @@ footer = """
 
 trim = true
 postprocessors = [
-  { pattern = '<REPO>', replace = "https://github.com/savente93/snakeoil" }, # replace repository URL ]
+  { pattern = '<REPO>', replace = "https://github.com/savente93/snakedown" }, # replace repository URL ]
 ]
 
 # render body even when there are no releases to process

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use clap_verbosity_flag::{LogLevel, Verbosity, VerbosityFilter};
-use snakeoil::render::front_matter::FrontMatterFormat;
+use snakedown::render::front_matter::FrontMatterFormat;
 
 #[allow(dead_code)]
 pub struct CustomLogLevel {}
@@ -103,7 +103,7 @@ mod tests {
     #[test]
     fn test_args_all_flags() -> Result<()> {
         let args = Args::parse_from([
-            "snakeoil",
+            "snakedown",
             "src/pkg",
             "dist",
             "--skip-undoc",

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -85,7 +85,7 @@ pub fn get_python_prefix(rel_path: &Path) -> Result<Option<String>> {
 
 /// determines the name of a python module which is the file stem of the .py file
 /// ```
-/// # use snakeoil::fs::get_module_name;
+/// # use snakedown::fs::get_module_name;
 /// # use color_eyre::Result;
 /// # use assert_fs::prelude::*;
 /// # fn foo() -> Result<()> {
@@ -140,7 +140,7 @@ pub fn create_empty_python_package_on_disk(root: &Path) -> Result<()> {
 
 /// determines all the submodules of a package (not recursively)
 /// ```
-/// # use snakeoil::fs::{get_package_modules, create_empty_python_package_on_disk};
+/// # use snakedown::fs::{get_package_modules, create_empty_python_package_on_disk};
 /// # use color_eyre::Result;
 /// # use assert_fs::prelude::*;
 /// # use std::fs::File;
@@ -182,7 +182,7 @@ pub fn get_package_modules(pkg_path: &Path) -> Result<Vec<PathBuf>> {
 
 /// determines all the subpackages of a package (not recursively)
 /// ```
-/// # use snakeoil::fs::{get_subpackages, create_empty_python_package_on_disk};
+/// # use snakedown::fs::{get_subpackages, create_empty_python_package_on_disk};
 /// # use color_eyre::Result;
 /// # use assert_fs::prelude::*;
 /// # fn foo() -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use color_eyre::eyre::Result;
-use snakeoil::render_docs;
+use snakedown::render_docs;
 use tracing::subscriber::set_global_default;
 
 mod cli;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -213,7 +213,7 @@ mod test {
         render::{front_matter::FrontMatterFormat, render_module, translate_filename},
     };
     fn test_dirty_module_str() -> &'static str {
-        r"'''This is a module that is used to test snakeoil.'''
+        r"'''This is a module that is used to test snakedown.'''
 
 from typing import Any
 
@@ -265,25 +265,25 @@ class Greeter:
     }
 
     fn expected_module_docs_rendered() -> &'static str {
-        r#"# snakeoil.testing.test_module
+        r#"# snakedown.testing.test_module
 
-This is a module that is used to test snakeoil.
+This is a module that is used to test snakedown.
 
 ## Exports:
 
-- [foo](#snakeoil.testing.test_module.foo)
+- [foo](#snakedown.testing.test_module.foo)
 
-## snakeoil.testing.test_module.foo
+## snakedown.testing.test_module.foo
 
 foo(bar: int) -> Dict[str, Any]
 
 this is a docstring for the foo function
 
-## snakeoil.testing.test_module.Greeter
+## snakedown.testing.test_module.Greeter
 
 this is a class docstring.
 
-### snakeoil.testing.test_module.Greeter.greet
+### snakedown.testing.test_module.Greeter.greet
 
 greet(self, name, *args, foo: str = "bar", **kwargs) -> Callable[[], None]
 
@@ -307,7 +307,7 @@ Callable[[], None]
         let mod_documentation = extract_module_documentation(
             &parsed,
             Some(String::from("test_module")),
-            Some(String::from("snakeoil.testing")),
+            Some(String::from("snakedown.testing")),
             false,
             false,
         );
@@ -320,7 +320,7 @@ Callable[[], None]
     }
     fn expected_module_docs_no_prefix_no_name_rendered() -> &'static str {
         r#"
-This is a module that is used to test snakeoil.
+This is a module that is used to test snakedown.
 
 ## Exports:
 
@@ -355,25 +355,25 @@ Callable[[], None]
     }
 
     fn expected_module_docs_only_prefix_rendered() -> &'static str {
-        r#"# snakeoil
+        r#"# snakedown
 
-This is a module that is used to test snakeoil.
+This is a module that is used to test snakedown.
 
 ## Exports:
 
-- [foo](#snakeoil.foo)
+- [foo](#snakedown.foo)
 
-## snakeoil.foo
+## snakedown.foo
 
 foo(bar: int) -> Dict[str, Any]
 
 this is a docstring for the foo function
 
-## snakeoil.Greeter
+## snakedown.Greeter
 
 this is a class docstring.
 
-### snakeoil.Greeter.greet
+### snakedown.Greeter.greet
 
 greet(self, name, *args, foo: str = "bar", **kwargs) -> Callable[[], None]
 
@@ -408,7 +408,7 @@ Callable[[], None]
         let mod_documentation = extract_module_documentation(
             &parsed,
             None,
-            Some(String::from("snakeoil")),
+            Some(String::from("snakedown")),
             false,
             false,
         );
@@ -421,25 +421,25 @@ Callable[[], None]
     }
 
     fn expected_module_docs_only_name_rendered() -> &'static str {
-        r#"# snakeoil
+        r#"# snakedown
 
-This is a module that is used to test snakeoil.
+This is a module that is used to test snakedown.
 
 ## Exports:
 
-- [foo](#snakeoil.foo)
+- [foo](#snakedown.foo)
 
-## snakeoil.foo
+## snakedown.foo
 
 foo(bar: int) -> Dict[str, Any]
 
 this is a docstring for the foo function
 
-## snakeoil.Greeter
+## snakedown.Greeter
 
 this is a class docstring.
 
-### snakeoil.Greeter.greet
+### snakedown.Greeter.greet
 
 greet(self, name, *args, foo: str = "bar", **kwargs) -> Callable[[], None]
 
@@ -460,8 +460,13 @@ Callable[[], None]
     #[test]
     fn render_module_documentation_only_name() -> Result<()> {
         let parsed = parse_python_str(test_dirty_module_str())?;
-        let mod_documentation =
-            extract_module_documentation(&parsed, Some("snakeoil".to_string()), None, false, false);
+        let mod_documentation = extract_module_documentation(
+            &parsed,
+            Some("snakedown".to_string()),
+            None,
+            false,
+            false,
+        );
 
         let rendered = render_module(mod_documentation, FrontMatterFormat::Markdown);
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -7,7 +7,7 @@ use tempfile::tempdir;
 fn test_cli_with_all_options() -> Result<()> {
     let tempdir = tempdir()?;
 
-    let mut cmd = Command::cargo_bin("snakeoil")?;
+    let mut cmd = Command::cargo_bin("snakedown")?;
     cmd.arg("tests/test_pkg")
         .arg(tempdir.path())
         .arg("--skip-undoc")


### PR DESCRIPTION
the name snakeoil was already taken on crates.io and it's early enough that a rename should be possible without too much fuss