### PR TITLE
fix: deprecate commitlintrc in favour of committed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+default_install_hook_types: [pre-commit, commit-msg]
 repos:
   - repo: https://github.com/doublify/pre-commit-rust
     rev: v1.0
@@ -23,10 +24,10 @@ repos:
     rev: v1.31.2
     hooks:
       - id: typos
-  - repo: https://github.com/savente93/commitlint-rs
-    rev: d0f10c617d701e29e5fbf153222a4e4120b994fa
+  - repo: https://github.com/crate-ci/committed
+    rev: v1.1.7
     hooks:
-      - id: commitlint
+      - id: committed
   - repo: local
     hooks:
     - id: check-no-dbg

--- a/committed.toml
+++ b/committed.toml
@@ -1,0 +1,4 @@
+style               = "conventional"
+ignore_author_re    = "(dependabot|renovate)"
+merge_commit        = false
+subject_capitalized = false


### PR DESCRIPTION
commitlinrc doesn't have pre commit hooks or github actions, but committed does, and they seem to have similar features so we're giving that one a try.