### PR TITLE
fix: revert rendering of submodules and exports

### DIFF
--- a/tests/rendered_full/_index.md
+++ b/tests/rendered_full/_index.md
@@ -3,10 +3,3 @@
 Root package initialization.
 
 This file marks the root as a Python package.
-
-## Submodules:
-
-- [_private](_private/_index.md)
-- [bar](bar.md)
-- [foo](foo.md)
-- [sub1](sub1/_index.md)

--- a/tests/rendered_full/_private/_index.md
+++ b/tests/rendered_full/_private/_index.md
@@ -3,7 +3,3 @@
 The _private subpackage
 
 This subpackage contains internal modules and functions intended for internal use.
-
-## Submodules:
-
-- [internals](internals.md)

--- a/tests/rendered_full/foo.md
+++ b/tests/rendered_full/foo.md
@@ -4,11 +4,6 @@ foo.py
 
 Example module demonstrating a calculator.
 
-## Exports:
-
-- [add](#test_pkg.foo.add)
-- [multiply](#test_pkg.foo.multiply)
-
 ## test_pkg.foo.add
 
 add(a: float, b: float) -> float

--- a/tests/rendered_full/sub1/_index.md
+++ b/tests/rendered_full/sub1/_index.md
@@ -3,8 +3,3 @@
 sub1 subpackage initialization.
 
 Marks sub1 as a package.
-
-## Submodules:
-
-- [mid](mid.md)
-- [sub2](sub2/_index.md)

--- a/tests/rendered_full/sub1/sub2/_index.md
+++ b/tests/rendered_full/sub1/sub2/_index.md
@@ -3,8 +3,3 @@
 sub2 subpackage initialization.
 
 Marks sub2 as a package.
-
-## Submodules:
-
-- [one](one.md)
-- [two](two.md)

--- a/tests/rendered_no_private/_index.md
+++ b/tests/rendered_no_private/_index.md
@@ -3,9 +3,3 @@
 Root package initialization.
 
 This file marks the root as a Python package.
-
-## Submodules:
-
-- [bar](bar.md)
-- [foo](foo.md)
-- [sub1](sub1/_index.md)

--- a/tests/rendered_no_private/foo.md
+++ b/tests/rendered_no_private/foo.md
@@ -4,11 +4,6 @@ foo.py
 
 Example module demonstrating a calculator.
 
-## Exports:
-
-- [add](#test_pkg.foo.add)
-- [multiply](#test_pkg.foo.multiply)
-
 ## test_pkg.foo.add
 
 add(a: float, b: float) -> float

--- a/tests/rendered_no_private/sub1/_index.md
+++ b/tests/rendered_no_private/sub1/_index.md
@@ -3,8 +3,3 @@
 sub1 subpackage initialization.
 
 Marks sub1 as a package.
-
-## Submodules:
-
-- [mid](mid.md)
-- [sub2](sub2/_index.md)

--- a/tests/rendered_no_private/sub1/sub2/_index.md
+++ b/tests/rendered_no_private/sub1/sub2/_index.md
@@ -3,8 +3,3 @@
 sub2 subpackage initialization.
 
 Marks sub2 as a package.
-
-## Submodules:
-
-- [one](one.md)
-- [two](two.md)

--- a/tests/zola_test_site/templates/index.html
+++ b/tests/zola_test_site/templates/index.html
@@ -12,11 +12,16 @@
       {% block content %}
       <h1>{{section.title}}</h1>
       {{section.content | safe}}
-      {% for post in section.pages %}
+      <h2>submodules:</h2>
         <ul>
-          <li><a href="{{ post.permalink }}">{{ post.title }}</a></li>
-        </ul
+      {% for sub_sec in section.subsections %}
+          {% set subsection = get_section(path=sub_sec) %}
+          <li><a href="{{ subsection.permalink }}">{{ subsection.title }}</a></li>
       {% endfor %}
+      {% for post in section.pages %}
+          <li><a href="{{ post.permalink }}">{{ post.title }}</a></li>
+      {% endfor %}
+        </ul
 
       {% endblock content %}
     </div>

--- a/tests/zola_test_site/templates/section.html
+++ b/tests/zola_test_site/templates/section.html
@@ -1,0 +1,1 @@
+{% extends "index.html" %}


### PR DESCRIPTION
These are too hacky for now, first proper linking has to be implement
before I can actually tackle this. This might get added back in when I
do proper linking, but for now the SSG probably also has functionalities
for this
