### PR TITLE
feat: implement config file 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,6 +1770,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,6 +1852,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "toml",
  "toml_edit",
  "tracing",
  "tracing-error",
@@ -2081,10 +2091,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -2093,8 +2127,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.6.9",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+dependencies = [
  "winnow",
 ]
 
@@ -2103,6 +2146,12 @@ name = "toml_write"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ flate2            = "1.1.2"
 
 lazy-regex = "3.4.1"
 reqwest    = { version = "0.12.20", features = ["blocking"] }
+toml = "0.9.2"
 
 
 [dev-dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,12 @@
+use color_eyre::Result;
 use std::path::PathBuf;
 
 use clap::Parser;
 use clap_verbosity_flag::{LogLevel, Verbosity, VerbosityFilter};
-use snakedown::render::SSG;
+use snakedown::{
+    config::{Config, ConfigBuilder},
+    render::SSG,
+};
 
 #[allow(dead_code)]
 pub struct CustomLogLevel {}
@@ -27,17 +31,56 @@ impl LogLevel for CustomLogLevel {
     }
 }
 
+pub fn resolve_runtime_config(args: Args) -> Result<Config> {
+    let mut config_builder = ConfigBuilder::default();
+
+    if let Some(config_file_path) = discover_config_file(args.config_file) {
+        let file_config_builder = ConfigBuilder::from_path(&config_file_path)?;
+        config_builder = config_builder.merge(file_config_builder);
+    }
+
+    let cli_args_builder = ConfigBuilder::default()
+        .with_output_dir(args.output_dir)
+        .with_pkg_path(args.pkg_path)
+        .with_skip_undoc(if args.skip_undoc { Some(true) } else { None })
+        .with_skip_private(if args.skip_private { Some(true) } else { None })
+        .with_exclude(args.exclude)
+        .with_ssg(args.ssg);
+
+    config_builder = config_builder.merge(cli_args_builder);
+
+    config_builder.build()
+}
+
+pub fn discover_config_file(arg_config_path: Option<PathBuf>) -> Option<PathBuf> {
+    let mut candidates = vec![];
+
+    if let Some(args_path) = arg_config_path {
+        candidates.push(args_path);
+    }
+
+    candidates.push(PathBuf::from("snakedown.toml"));
+    candidates.push(PathBuf::from("$HOME/.config/snakedown/snakedown.toml"));
+    candidates
+        .into_iter()
+        .find(|candidate| candidate.exists() && candidate.is_file())
+}
+
 #[derive(Parser)]
 #[command(version, about, long_about= None)]
 pub struct Args {
     #[command(flatten)]
     pub verbose: Verbosity,
 
-    #[arg(default_value = ".")]
-    pub pkg_path: PathBuf,
+    /// The path of the root of the package
+    pub pkg_path: Option<PathBuf>,
 
-    #[arg(default_value = "_build")]
-    pub output_dir: PathBuf,
+    /// The directory where to put the rendered docs
+    pub output_dir: Option<PathBuf>,
+
+    /// The path to the configuration file
+    #[arg(long, short)]
+    pub config_file: Option<PathBuf>,
 
     /// Do not render undocumented functions, classes or modules
     #[arg(long, default_value_t = false)]
@@ -47,13 +90,13 @@ pub struct Args {
     #[arg(long, default_value_t = false)]
     pub skip_private: bool,
 
-    /// any files that should be excluded, can be file or directories and specific multiple times but currently globs are not supported
+    /// Any files that should be excluded, can be file or directories and specific multiple times but currently globs are not supported
     #[arg(short, long)]
-    pub exclude: Vec<PathBuf>,
+    pub exclude: Option<Vec<PathBuf>>,
 
     /// What format to render the front matter in, (zola, hugo, plain markdown, etc.)
-    #[arg(short, long, value_enum, default_value_t = SSG::Markdown)]
-    pub ssg: SSG,
+    #[arg(short, long, value_enum)]
+    pub ssg: Option<SSG>,
 }
 
 #[cfg(test)]
@@ -90,13 +133,13 @@ mod tests {
 
     #[test]
     fn test_args_defaults() -> Result<()> {
-        let args = Args::parse_from(["mybin"]);
-        assert_eq!(args.pkg_path, PathBuf::from("."));
-        assert_eq!(args.output_dir, PathBuf::from("_build"));
+        let args = Args::parse_from(["snakedown"]);
+        assert!(args.pkg_path.is_none());
+        assert!(args.output_dir.is_none());
         assert!(!args.skip_undoc);
         assert!(!args.skip_private);
-        assert!(args.exclude.is_empty());
-        assert_eq!(args.ssg, SSG::Markdown);
+        assert!(args.exclude.is_none());
+        assert!(args.ssg.is_none());
         Ok(())
     }
 
@@ -117,28 +160,28 @@ mod tests {
             "-v",
             "-v",
         ]);
-        assert_eq!(args.pkg_path, PathBuf::from("src/pkg"));
-        assert_eq!(args.output_dir, PathBuf::from("dist"));
+        assert_eq!(args.pkg_path, Some(PathBuf::from("src/pkg")));
+        assert_eq!(args.output_dir, Some(PathBuf::from("dist")));
         assert!(args.skip_undoc);
         assert!(args.skip_private);
         assert_eq!(
             args.exclude,
-            vec![
+            Some(vec![
                 PathBuf::from("path/to/exclude1"),
                 PathBuf::from("path/to/exclude2")
-            ]
+            ])
         );
         // Verbosity should be INFO with -v -v (test indirectly)
         let level = args.verbose.log_level();
         assert_eq!(level, Some(Level::Info));
-        assert_eq!(args.ssg, SSG::Markdown);
+        assert_eq!(args.ssg, Some(SSG::Markdown));
         Ok(())
     }
 
     #[test]
     fn test_args_exclude_short_flag() -> Result<()> {
         let args = Args::parse_from(["mybin", "-e", "excluded"]);
-        assert_eq!(args.exclude, vec![PathBuf::from("excluded")]);
+        assert_eq!(args.exclude, Some(vec![PathBuf::from("excluded")]));
         Ok(())
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,131 @@
+use color_eyre::Result;
+use serde::{Deserialize, Serialize};
+use std::{
+    fs::File,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+};
+
+use crate::render::SSG;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Config {
+    pub minify: bool,
+    pub output_dir: PathBuf,
+    pub pkg_path: PathBuf,
+    pub skip_undoc: bool,
+    pub skip_private: bool,
+    pub exclude: Vec<PathBuf>,
+    pub ssg: SSG,
+}
+
+#[derive(Default, Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub struct ConfigBuilder {
+    minify: Option<bool>,
+    output_dir: Option<PathBuf>,
+    pkg_path: Option<PathBuf>,
+    skip_undoc: Option<bool>,
+    skip_private: Option<bool>,
+    exclude: Option<Vec<PathBuf>>,
+    ssg: Option<SSG>,
+}
+
+impl ConfigBuilder {
+    pub fn with_minify(mut self, minify: bool) -> Self {
+        self.minify = Some(minify);
+        self
+    }
+    pub fn with_output_dir(mut self, output_dir: PathBuf) -> Self {
+        self.output_dir = Some(output_dir);
+        self
+    }
+    pub fn with_pkg_path(mut self, pkg_path: PathBuf) -> Self {
+        self.pkg_path = Some(pkg_path);
+        self
+    }
+    pub fn with_skip_undoc(mut self, skip_undoc: bool) -> Self {
+        self.skip_undoc = Some(skip_undoc);
+        self
+    }
+    pub fn with_skip_private(mut self, skip_private: bool) -> Self {
+        self.skip_private = Some(skip_private);
+        self
+    }
+    pub fn exclude_paths(mut self, excluded: Vec<PathBuf>) -> Self {
+        match &mut self.exclude {
+            Some(v) => v.extend(excluded),
+            None => self.exclude = Some(excluded),
+        }
+        self
+    }
+    pub fn exclude_path(mut self, excluded: PathBuf) -> Self {
+        match &mut self.exclude {
+            Some(v) => v.push(excluded),
+            None => self.exclude = Some(vec![excluded]),
+        }
+        self
+    }
+    pub fn with_exclude(mut self, exclude: Vec<PathBuf>) -> Self {
+        self.exclude = Some(exclude);
+        self
+    }
+    pub fn with_ssg(mut self, ssg: SSG) -> Self {
+        self.ssg = Some(ssg);
+        self
+    }
+    pub fn build(self) -> Result<Config> {
+        Ok(Config {
+            minify: self.minify.unwrap_or(false),
+            output_dir: self.output_dir.unwrap_or(PathBuf::from("_build")),
+            pkg_path: self.pkg_path.unwrap_or(PathBuf::from(".")),
+            skip_undoc: self.skip_undoc.unwrap_or(true),
+            skip_private: self.skip_private.unwrap_or(false),
+            exclude: self.exclude.unwrap_or_default(),
+            ssg: self.ssg.unwrap_or(SSG::Markdown),
+        })
+    }
+
+    pub fn to_file(&self, path: &Path) -> Result<()> {
+        let serialized = toml::to_string(&self)?;
+        let mut file = File::create(path)?;
+        file.write_all(serialized.as_bytes())?;
+        Ok(())
+    }
+
+    pub fn from_path(path: &Path) -> Result<ConfigBuilder> {
+        let mut file_contents = String::new();
+        let mut file = File::open(path)?;
+        file.read_to_string(&mut file_contents)?;
+        let config: ConfigBuilder = toml::from_str(&file_contents)?;
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::ConfigBuilder;
+    use assert_fs::TempDir;
+    use color_eyre::Result;
+
+    #[test]
+    fn empty_builder_creates_valid_config() -> Result<()> {
+        let config = ConfigBuilder::default().build();
+        assert!(config.is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn config_round_trip() -> Result<()> {
+        let builder = ConfigBuilder::default()
+            .with_minify(true)
+            .with_skip_undoc(false)
+            .with_skip_private(true);
+
+        let tmp_dir = TempDir::new()?;
+        let path = tmp_dir.join("build_config.toml");
+        builder.to_file(&path)?;
+        let deserialized = ConfigBuilder::from_path(&path)?;
+        assert_eq!(builder, deserialized);
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod fs;
 pub mod indexing;
 pub mod parsing;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,10 @@
 use color_eyre::eyre::Result;
-use snakedown::{
-    render::{
-        SSG,
-        formats::{Renderer, md::MdRenderer, zola::ZolaRenderer},
-    },
-    render_docs,
-};
+use snakedown::render_docs;
 use tracing::subscriber::set_global_default;
 
 mod cli;
 
-use crate::cli::Args;
+use crate::cli::{Args, resolve_runtime_config};
 use clap::Parser;
 
 #[allow(clippy::missing_errors_doc)]
@@ -25,18 +19,14 @@ async fn main() -> Result<()> {
 
     set_global_default(subscriber)?;
 
-    let renderer: Box<dyn Renderer> = match args.ssg {
-        SSG::Markdown => Box::new(MdRenderer::new()),
-        SSG::Zola => Box::new(ZolaRenderer::new()),
-    };
-
+    let config = resolve_runtime_config(args)?;
     render_docs(
-        &args.pkg_path,
-        &args.output_dir,
-        args.skip_private,
-        args.skip_undoc,
-        args.exclude,
-        &renderer,
+        &config.pkg_path,
+        &config.output_dir,
+        config.skip_private,
+        config.skip_undoc,
+        config.exclude,
+        &config.renderer,
     )?;
 
     Ok(())

--- a/src/parsing/sphinx/inv_file.rs
+++ b/src/parsing/sphinx/inv_file.rs
@@ -232,10 +232,6 @@ mod test {
 
         let decompressed = decompress_remaining_zlib_data(&mut reader)?;
 
-        let mut f = File::create("full_example.inv")?;
-
-        f.write_all(decompressed.as_bytes())?;
-
         for line in decompressed.lines() {
             let sphinx_ref = ExternalSphinxRef::try_from(line);
             assert!(sphinx_ref.is_ok(), "failed to parse line: {line}");

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -3,6 +3,7 @@ pub mod expr;
 pub mod formats;
 
 use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
 use std::{
     ffi::OsStr,
     path::{Path, PathBuf},
@@ -19,7 +20,7 @@ use crate::{
     render::formats::Renderer,
 };
 
-#[derive(Clone, Copy, Debug, Display, ValueEnum, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Display, ValueEnum, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SSG {
     Markdown,
     Zola,


### PR DESCRIPTION
This PR adds support for taking options from a config file. for now it's not super necessary yet, but as we start adding options (such as external sites to link to) the cli is quickly gonna get out of hand for normal use, so it's good to get it in now so it can keep growing with new use cases we add. 

Currently the order of precedence is: 
1. command line arguments
2. config file (either found at default locations or provided from cli)
3. hard coded defaults 

We add a builler patterns so we can more easily create configs with the different precedence, and also do validation when necessary without having to burden the config with all that logic. 

With this all CLI options become optional