### PR TITLE
feat: implement passing links to external inventory

### DIFF
--- a/snakedown.example.toml
+++ b/snakedown.example.toml
@@ -1,0 +1,8 @@
+output_dir = "_build"
+pkg_path = "."
+skip_undoc = true
+skip_private = false
+ssg = "markdown"
+exclude = []
+
+[externals]

--- a/snakedown.example.toml
+++ b/snakedown.example.toml
@@ -2,7 +2,11 @@ output_dir = "_build"
 pkg_path = "."
 skip_undoc = true
 skip_private = false
-ssg = "markdown"
+ssg = "Markdown"
 exclude = []
 
 [externals]
+builtins = {name = "Python", url = "https://docs.python.org/3/"}
+
+[render.zola]
+use_shortcodes = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,6 +97,10 @@ pub struct Args {
     /// What format to render the front matter in, (zola, hugo, plain markdown, etc.)
     #[arg(short, long, value_enum)]
     pub ssg: Option<SSG>,
+
+    /// Link to external documentation to link to. should be in the form of name=<link>
+    #[arg(long)]
+    pub externals: Option<Vec<String>>,
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,7 +32,7 @@ impl LogLevel for CustomLogLevel {
 }
 
 pub fn resolve_runtime_config(args: Args) -> Result<Config> {
-    let mut config_builder = ConfigBuilder::default();
+    let mut config_builder = ConfigBuilder::default().init_with_defaults();
 
     if let Some(config_file_path) = discover_config_file(args.config_file) {
         let file_config_builder = ConfigBuilder::from_path(&config_file_path)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,10 +97,6 @@ pub struct Args {
     /// What format to render the front matter in, (zola, hugo, plain markdown, etc.)
     #[arg(short, long, value_enum)]
     pub ssg: Option<SSG>,
-
-    /// Link to external documentation to link to. should be in the form of name=<link>
-    #[arg(long)]
-    pub externals: Option<Vec<String>>,
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,12 @@
 use color_eyre::Result;
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::HashMap,
     fs::File,
     io::{Read, Write},
     path::{Path, PathBuf},
 };
+use url::Url;
 
 use crate::render::{
     SSG,
@@ -16,8 +18,9 @@ pub struct Config {
     pub pkg_path: PathBuf,
     pub skip_undoc: bool,
     pub skip_private: bool,
-    pub exclude: Vec<PathBuf>,
     pub renderer: Box<dyn Renderer>,
+    pub exclude: Vec<PathBuf>,
+    pub externals: HashMap<String, Url>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default)]
@@ -36,12 +39,25 @@ pub struct ConfigBuilder {
     pkg_path: Option<PathBuf>,
     skip_undoc: Option<bool>,
     skip_private: Option<bool>,
-    exclude: Option<Vec<PathBuf>>,
     ssg: Option<SSG>,
     render: Option<RenderConfig>,
+    exclude: Option<Vec<PathBuf>>,
+    externals: Option<HashMap<String, String>>,
 }
 
 impl ConfigBuilder {
+    pub fn init_with_defaults(mut self) -> Self {
+        self = self
+            .with_output_dir(Some(PathBuf::from("_build")))
+            .with_skip_undoc(Some(true))
+            .with_skip_private(Some(false))
+            .with_pkg_path(Some(PathBuf::from(".")))
+            .with_exclude(Some(Vec::new()))
+            .with_ssg(Some(SSG::Markdown))
+            .with_externals(Some(HashMap::new()));
+
+        self
+    }
     pub fn with_output_dir(mut self, output_dir: Option<PathBuf>) -> Self {
         if output_dir.is_some() {
             self.output_dir = output_dir;
@@ -84,6 +100,23 @@ impl ConfigBuilder {
         }
         self
     }
+    pub fn add_external(&mut self, name: String, link: String) -> Result<()> {
+        if self.externals.is_none() {
+            self.externals = Some(HashMap::new());
+        }
+
+        let externals = self.externals.get_or_insert_default();
+
+        externals.insert(name, link);
+
+        Ok(())
+    }
+    pub fn with_externals(mut self, externals: Option<HashMap<String, String>>) -> Self {
+        if externals.is_some() {
+            self.externals = externals
+        }
+        self
+    }
     pub fn with_ssg(mut self, ssg: Option<SSG>) -> Self {
         if ssg.is_some() {
             self.ssg = ssg;
@@ -100,6 +133,15 @@ impl ConfigBuilder {
             }
         };
 
+        let mut external_linkings = HashMap::new();
+
+        if let Some(external_links) = self.externals {
+            for (name, link) in external_links {
+                let url = Url::parse(&link)?;
+                external_linkings.insert(name, url);
+            }
+        }
+
         Ok(Config {
             output_dir: self.output_dir.unwrap_or(PathBuf::from("_build")),
             pkg_path: self.pkg_path.unwrap_or(PathBuf::from(".")),
@@ -107,6 +149,7 @@ impl ConfigBuilder {
             skip_private: self.skip_private.unwrap_or(false),
             exclude: self.exclude.unwrap_or_default(),
             renderer,
+            externals: external_linkings,
         })
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,8 +15,8 @@ use crate::render::{
 
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub struct ExternalIndex {
-    name: Option<String>,
-    url: String,
+    pub name: Option<String>,
+    pub url: String,
 }
 
 pub struct Config {
@@ -26,7 +26,7 @@ pub struct Config {
     pub skip_private: bool,
     pub renderer: Box<dyn Renderer>,
     pub exclude: Vec<PathBuf>,
-    pub externals: HashMap<String, Url>,
+    pub externals: HashMap<String, ExternalIndex>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default)]
@@ -163,9 +163,13 @@ impl ConfigBuilder {
         let mut external_linkings = HashMap::new();
 
         if let Some(external_links) = self.externals {
-            for (name, external_index) in external_links {
-                let url = Url::parse(&external_index.url)?;
-                external_linkings.insert(name, url);
+            for (key, external_index) in external_links {
+                let _ = Url::parse(&external_index.url)?; // check if url is valid
+                let external_index = ExternalIndex {
+                    name: external_index.name,
+                    url: external_index.url,
+                };
+                external_linkings.insert(key, external_index);
             }
         }
 

--- a/src/indexing/cache.rs
+++ b/src/indexing/cache.rs
@@ -1,5 +1,4 @@
 use std::{
-    env,
     fs::{create_dir_all, exists},
     path::PathBuf,
 };
@@ -9,10 +8,7 @@ use color_eyre::Result;
 /// `$HOME/.snakedown/cache` if $HOME exists and `./.shakedown/cache` else
 // TODO: start tying different combinations of XDG_CACHE_HOME and APPDIR where appropriate
 pub fn get_cache_path() -> PathBuf {
-    env::home_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".snakedown")
-        .join("cache")
+    PathBuf::from(".").join(".snakedown").join("cache")
 }
 
 /// checks if cache exists at the path returned by `get_cache_path` if so that is returned

--- a/src/indexing/fetch.rs
+++ b/src/indexing/fetch.rs
@@ -1,59 +1,70 @@
-use std::{fs::File, io::Write, path::PathBuf};
+use std::{
+    fs::{File, remove_file},
+    io::Write,
+    path::PathBuf,
+};
 
-use reqwest::blocking::Response;
+use reqwest::Response;
 
 use crate::indexing::cache::init_cache;
 use color_eyre::Result;
 
-pub fn cache_remote_objects_inv(
+pub async fn cache_remote_objects_inv(
     url: &str,
     project_name: String,
     maybe_cache_path: Option<PathBuf>,
-) -> Result<()> {
-    let response = fetch_objects_inv_blocking(url)?;
-    let data = response.bytes()?;
-
-    create_object_inv_cache(data.to_vec(), project_name, maybe_cache_path)?;
-    Ok(())
-}
-
-pub fn fetch_objects_inv_blocking(url: &str) -> Result<Response> {
-    Ok(reqwest::blocking::get(url)?)
-}
-
-fn create_object_inv_cache(
-    data: Vec<u8>,
-    project_name: String,
-    maybe_cache_path: Option<PathBuf>,
+    force: bool,
 ) -> Result<()> {
     let cache_path = init_cache(maybe_cache_path)?
         .join("sphinx")
         .join(PathBuf::from(project_name.to_lowercase()))
         .with_extension("inv");
 
+    if cache_path.exists() {
+        if force {
+            remove_file(&cache_path)?;
+        } else {
+            // object is already cached so we don't have to do anything else
+            return Ok(());
+        }
+    }
+
+    let response = fetch_objects_inv_blocking(url).await?;
+    let data = response.bytes().await?;
+
     let mut file = File::create(cache_path)?;
 
     file.write_all(&data)?;
-
     Ok(())
+}
+
+pub async fn fetch_objects_inv_blocking(url: &str) -> Result<Response> {
+    Ok(reqwest::get(url).await?)
 }
 
 #[cfg(test)]
 mod test {
 
-    use std::fs::exists;
+    use std::fs::{File, create_dir_all, exists};
 
     use assert_fs::TempDir;
     use color_eyre::Result;
+    use walkdir::WalkDir;
 
     use crate::indexing::fetch::cache_remote_objects_inv;
 
-    #[test]
-    fn cache_clean_numpy_obj_inv() -> Result<()> {
+    #[tokio::test]
+    async fn cache_clean_numpy_obj_inv() -> Result<()> {
         let url = "https://numpy.org/doc/stable/objects.inv";
 
         let tmp_dir = TempDir::new()?;
-        cache_remote_objects_inv(url, "numpy".to_string(), Some(tmp_dir.path().to_path_buf()))?;
+        cache_remote_objects_inv(
+            url,
+            "numpy".to_string(),
+            Some(tmp_dir.path().to_path_buf()),
+            false,
+        )
+        .await?;
 
         assert!(exists(
             tmp_dir
@@ -62,6 +73,50 @@ mod test {
                 .join("numpy")
                 .with_extension("inv")
         )?);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cache_force() -> Result<()> {
+        let url = "https://numpy.org/doc/stable/objects.inv";
+
+        let tmp_dir = TempDir::new()?;
+        let cache_path = tmp_dir.path().join("sphinx");
+        let obj_path = cache_path.join("numpy.inv");
+        create_dir_all(&cache_path)?;
+
+        let _ = File::create(&obj_path)?;
+
+        cache_remote_objects_inv(
+            url,
+            "numpy".to_string(),
+            Some(tmp_dir.path().to_path_buf()),
+            false,
+        )
+        .await?;
+
+        {
+            let file_size = std::fs::metadata(&obj_path)?.len();
+            assert!(file_size == 0);
+        }
+
+        cache_remote_objects_inv(
+            url,
+            "numpy".to_string(),
+            Some(tmp_dir.path().to_path_buf()),
+            true,
+        )
+        .await?;
+
+        for entry in WalkDir::new(tmp_dir.path()).follow_links(true) {
+            let entry = entry?;
+            println!("{}", entry.path().display());
+        }
+        {
+            let file_size = std::fs::metadata(&obj_path)?.len();
+            assert!(file_size > 0);
+        }
 
         Ok(())
     }

--- a/src/render/formats/md.rs
+++ b/src/render/formats/md.rs
@@ -43,6 +43,7 @@ impl Renderer for MdRenderer {
 
 #[cfg(test)]
 mod test {
+    use pretty_assertions::assert_eq;
     use std::path::PathBuf;
 
     use color_eyre::Result;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -21,6 +21,7 @@ use crate::{
 };
 
 #[derive(Clone, Copy, Debug, Display, ValueEnum, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "lowercase"))]
 pub enum SSG {
     Markdown,
     Zola,


### PR DESCRIPTION
This PR adds support for listing links to external documentation links and retrieving their `objects.inv` file similar to sphinx. The files are cached, so no requests have to be made if they are already there. Currently we don't do any checking of contents or whether they might be outdated, that could be a future improvement. (see ticket I'm about to make). Before we do the parsing etc, those will be fetched first if necessary. Currently if one fails the process just fails all over, at some point better error handling should be in place to manage this a bit more gracefully, in addition to better error/warning messages.