### PR TITLE
feat: implement link rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,6 +1858,7 @@ dependencies = [
  "tracing-error",
  "tracing-subscriber",
  "tracing-test",
+ "url",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ flate2            = "1.1.2"
 lazy-regex = "3.4.1"
 reqwest    = { version = "0.12.20", features = ["blocking"] }
 toml = "0.9.2"
+url = "2.5.4"
 
 
 [dev-dependencies]

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,7 +82,7 @@ impl ConfigBuilder {
     pub fn build(self) -> Result<Config> {
         let renderer: Box<dyn Renderer> = match self.ssg {
             Some(SSG::Markdown) | None => Box::new(MdRenderer::new()),
-            Some(SSG::Zola) => Box::new(ZolaRenderer::new()),
+            Some(SSG::Zola) => Box::new(ZolaRenderer::new(false)),
         };
 
         Ok(Config {

--- a/src/render/formats/mod.rs
+++ b/src/render/formats/mod.rs
@@ -1,9 +1,16 @@
+use std::path::PathBuf;
+
+use color_eyre::Result;
+use url::Url;
+
 pub mod md;
 pub mod zola;
 
 pub trait Renderer {
     fn render_header(&self, content: &str, level: usize) -> String;
     fn render_front_matter(&self, title: Option<&str>) -> String;
+    fn render_external_ref(&self, text: String, base_url: Url, rel_url: String) -> Result<String>;
+    fn render_internal_ref(&self, text: String, rel_path: PathBuf) -> Result<String>;
 }
 
 impl<T: Renderer + ?Sized> Renderer for &T {
@@ -11,8 +18,14 @@ impl<T: Renderer + ?Sized> Renderer for &T {
         (**self).render_header(content, level)
     }
 
+    fn render_external_ref(&self, text: String, base_url: Url, rel_url: String) -> Result<String> {
+        (**self).render_external_ref(text, base_url, rel_url)
+    }
     fn render_front_matter(&self, title: Option<&str>) -> String {
         (**self).render_front_matter(title)
+    }
+    fn render_internal_ref(&self, text: String, rel_path: PathBuf) -> Result<String> {
+        (**self).render_internal_ref(text, rel_path)
     }
 }
 
@@ -22,5 +35,11 @@ impl Renderer for Box<dyn Renderer> {
     }
     fn render_front_matter(&self, title: Option<&str>) -> String {
         (**self).render_front_matter(title)
+    }
+    fn render_external_ref(&self, text: String, base_url: Url, rel_url: String) -> Result<String> {
+        (**self).render_external_ref(text, base_url, rel_url)
+    }
+    fn render_internal_ref(&self, text: String, rel_path: PathBuf) -> Result<String> {
+        (**self).render_internal_ref(text, rel_path)
     }
 }

--- a/src/render/formats/zola.rs
+++ b/src/render/formats/zola.rs
@@ -92,6 +92,15 @@ mod test {
     }
 
     #[test]
+    fn zola_internal_link_no_shortcode() -> Result<()> {
+        assert_eq!(
+            ZolaRenderer::new(false)
+                .render_internal_ref("Baz".to_string(), PathBuf::from("foo/bar/baz/index.md"))?,
+            r#"[Baz](@/foo/bar/baz/index.md)"#
+        );
+        Ok(())
+    }
+    #[test]
     fn zola_external_link_no_shortcode() -> Result<()> {
         assert_eq!(
             ZolaRenderer::new(false).render_external_ref(
@@ -103,6 +112,16 @@ mod test {
         );
         Ok(())
     }
+    #[test]
+    fn zola_internal_link_with_shortcode() -> Result<()> {
+        assert_eq!(
+            ZolaRenderer::new(true)
+                .render_internal_ref("Baz".to_string(), PathBuf::from("foo/bar/baz/index.md"))?,
+            r#"{{ snakedown_internal_ref(text="Baz", path="@/foo/bar/baz/index.md") }}"#
+        );
+        Ok(())
+    }
+
     #[test]
     fn zola_external_link_with_shortcode() -> Result<()> {
         assert_eq!(

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -483,7 +483,7 @@ Callable[[], None]
             false,
         );
 
-        let rendered = render_module(mod_documentation, &ZolaRenderer::new());
+        let rendered = render_module(mod_documentation, &ZolaRenderer::new(false));
 
         assert_eq!(rendered, expected_module_docs_zola_rendered());
 


### PR DESCRIPTION
This PR makes a first attempt at link rendering. We'll have to see if the API is flexible enough to work once we start actually implementing linking, but it's a good first pass. In addition it also implements the option to pass config arguments to renderers so people get a little more control over how the outptut is generated. I'm waiting to fully test all this in integration test for linking to be fully implemented. 