### PR TITLE
fix: fix just zola command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ _build/
 tests/zola_test_site/content/*
 
 .bacon-locations
+
+tests/zola_test_site/public

--- a/justfile
+++ b/justfile
@@ -77,5 +77,5 @@ pr: ci
     gh pr create --web --fill-first
 
 zola:
-    cargo r -- tests/test_pkg tests/zola_test_site/content/ --format zola -e tests/test_pkg/excluded_file.py -e tests/test_pkg/excluded_module/
+    cargo r -- tests/test_pkg tests/zola_test_site/content/ --ssg zola -e tests/test_pkg/excluded_file.py -e tests/test_pkg/excluded_module/
     zola --root tests/zola_test_site build


### PR DESCRIPTION
cli changed since this command was written, so this PR fixes it, and also adds the `zola_test_site/public` to `.gitignore` so we don't end up with accidentally huge commits. 