### PR TITLE
feat: add ability to read config from pyproject

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "boxcar"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -1020,12 +1026,14 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1067,6 +1075,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1180,7 +1197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ea0ed76adf7defc1a92240b5c36d5368cfe9251640dcce5bd2d0b7c1fd87aeb"
 dependencies = [
  "hashbrown 0.14.5",
- "itertools",
+ "itertools 0.11.0",
  "libm",
  "ryu",
 ]
@@ -1204,7 +1221,7 @@ version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34a79feebb2bc9aa7762047c8e5495269a367da6b5a90a99882a0aeeac1841f7"
 dependencies = [
- "itertools",
+ "itertools 0.11.0",
  "libm",
  "malachite-base",
 ]
@@ -1215,7 +1232,7 @@ version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f235d5747b1256b47620f5640c2a17a88c7569eebdf27cd9cb130e1a619191"
 dependencies = [
- "itertools",
+ "itertools 0.11.0",
  "malachite-base",
  "malachite-nz",
 ]
@@ -1422,6 +1439,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pep440_rs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31095ca1f396e3de32745f42b20deef7bc09077f918b085307e8eab6ddd8fb9c"
+dependencies = [
+ "once_cell",
+ "serde",
+ "unicode-width 0.2.0",
+ "unscanny",
+ "version-ranges",
+]
+
+[[package]]
+name = "pep508_rs"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faee7227064121fcadcd2ff788ea26f0d8f2bd23a0574da11eca23bc935bcc05"
+dependencies = [
+ "boxcar",
+ "indexmap",
+ "itertools 0.13.0",
+ "once_cell",
+ "pep440_rs",
+ "regex",
+ "rustc-hash 2.1.1",
+ "serde",
+ "smallvec",
+ "thiserror 1.0.69",
+ "unicode-width 0.2.0",
+ "url",
+ "urlencoding",
+ "version-ranges",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1643,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyproject-toml"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d755483ad14b49e76713b52285235461a5b4f73f17612353e11a5de36a5fd2"
+dependencies = [
+ "indexmap",
+ "pep440_rs",
+ "pep508_rs",
+ "serde",
+ "thiserror 2.0.17",
+ "toml",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,6 +1823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,14 +1894,14 @@ checksum = "868f724daac0caf9bd36d38caf45819905193a901e8f1c983345a68e18fb2abb"
 dependencies = [
  "anyhow",
  "is-macro",
- "itertools",
+ "itertools 0.11.0",
  "lalrpop-util",
  "log",
  "malachite-bigint",
  "num-traits",
  "phf",
  "phf_codegen",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "rustpython-ast",
  "rustpython-parser-core",
  "tiny-keccak",
@@ -1920,18 +1992,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1952,11 +2034,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2047,6 +2129,7 @@ dependencies = [
  "flate2",
  "lazy-regex",
  "pretty_assertions",
+ "pyproject-toml",
  "reqwest",
  "rustpython-parser",
  "serde",
@@ -2215,6 +2298,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl 2.0.17",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2318,12 +2441,12 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.2"
+version = "0.9.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
@@ -2333,11 +2456,11 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.0"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2355,18 +2478,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.1"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.2"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tower"
@@ -2634,6 +2757,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unscanny"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2648,7 +2777,14 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -2673,6 +2809,15 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-ranges"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3595ffe225639f1e0fd8d7269dcc05d2fbfea93cfac2fea367daf1adb60aae91"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "version_check"
@@ -3013,9 +3158,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ reqwest    = { version = "0.12.20", features = ["blocking"] }
 toml = "0.9.2"
 url = "2.5.4"
 tera = "1.20.1"
+pyproject-toml = "0.13.7"
 
 
 [dev-dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,13 @@ impl LogLevel for CustomLogLevel {
 pub fn resolve_runtime_config(args: Args) -> Result<Config> {
     let mut config_builder = ConfigBuilder::default().init_with_defaults();
 
+    let pyproject_path = PathBuf::from("pyproject.toml");
+
+    if pyproject_path.exists() && pyproject_path.is_file() {
+        let pyproject_config = ConfigBuilder::from_pyproject(&pyproject_path)?;
+        config_builder = config_builder.merge(pyproject_config);
+    }
+
     if let Some(config_file_path) = discover_config_file(args.config_file) {
         let file_config_builder = ConfigBuilder::from_path(&config_file_path)?;
         config_builder = config_builder.merge(file_config_builder);

--- a/tests/test_pyproject.toml
+++ b/tests/test_pyproject.toml
@@ -1,0 +1,403 @@
+# This pyproject was taken from https://github.com/Deltares/hydromt
+# and is only here for the purposes of testing the parsing
+[build-system]
+requires = ["flit_core >=3.4.0,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "hydromt"
+authors = [
+	{ name = "Dirk Eilander", email = "dirk.eilander@deltares.nl" },
+	{ name = "Hélène Boisgontier", email = "helene.boisgontier@deltares.nl" },
+	{ name = "Sam Vente", email = "sam.vente@deltares.nl" },
+]
+dependencies = [
+	"affine",                 # Spatial rasterers affine transformations (bbox pixel coalision)
+	"bottleneck",             # Spearmen rank computation
+	"click",                  # CLI configuration
+	"dask",                   # lazy computing
+	"fsspec[http]",           # general file systems utilities
+	"geopandas[all]>=0.10",   # pandas but geo, wraps fiona and shapely
+	"importlib_metadata",     # entrypoints backport
+	"mercantile",             # tile handling
+	"netcdf4",                # netcfd IO
+	"numba",                  # speed up computations (used in e.g. stats)
+	"numpy",                  # pin necessary to ensure compatibility with C headers
+	"packaging",              # compare versions of hydromt
+	"pandas",                 # Dataframes
+	"pooch",                  # data fetching
+	"pyarrow",
+	"pydantic~=2.4",          # Validation
+	"pydantic-settings~=2.2", # Settings Management
+	"pyflwdir>=0.5.4",        # Height models and derivatives
+	"pyogrio>=0.6",           # io for geopandas dataframes
+	"pyproj",                 # projections for Coordinate reference systems
+	"pystac",                 # STAC integration
+	"pyyaml",                 # yaml interface
+	"rasterio",               # raster wrapper around gdal
+	"requests",               # download stuff
+	"rioxarray",              # wraps rasterio and xarray. Almost superseded by hydromt/raster.py
+	"scipy",                  # scientific utilities
+	"shapely>=2.1.0",         # geometry transforms
+	"tomli",                  # parsing toml files
+	"tomli-w",                # writing toml files
+	"universal_pathlib>=0.2", # provides path compatibility between different filesystems
+	"xarray",                 # ndim data arrays
+	"xmltodict",              # xml parser also used to read VRT
+	"xugrid>=0.9.0",          # xarray wrapper for mesh processing
+	"zarr>=3.1,<4",           # zarr
+]
+
+requires-python = ">=3.11"
+readme = "README.rst"
+classifiers = [
+	"Development Status :: 5 - Production/Stable",
+	"Intended Audience :: Developers",
+	"Intended Audience :: Science/Research",
+	"Topic :: Scientific/Engineering :: Hydrology",
+	"License :: OSI Approved :: MIT License",
+	"Programming Language :: Python :: 3",
+	"Programming Language :: Python :: 3.11",
+	"Programming Language :: Python :: 3.12",
+	"Programming Language :: Python :: 3.13",
+]
+dynamic = ['version', 'description']
+
+[project.optional-dependencies]
+io = [
+	"gcsfs>=2023.12.1", # google cloud file system
+	"fastparquet",      # parquet IO
+	"openpyxl",         # excel IO
+	"pillow",           # image IO
+	"s3fs",             # S3 file system
+]
+vrt = [
+	"gdal>=3.5.0", # vrt for caching of mosaic raster
+]
+extra = [
+	"matplotlib", # plotting; required for slippy tiles
+	"pyet",       # calc evapotranspiration, quite well used, used in all wflow models but domain specific
+]
+dev = [
+	"flit",            # needed to publish to pypi
+	"mypy",            # static type checking
+	"pandas-stubs",    # type hints for pandas
+	"pre-commit",      # linting
+	"ruff",            # linting
+	"twine",           # needed to publish to pypi
+	"types-openpyxl",  # type hints for openpyxl
+	"types-PyYAML",    # type hints for pyyaml
+	"types-Pillow",    # type hints for pillow
+	"types-requests",  # type hints for requests
+	"types-xmltodict", # type hints for xmltodict
+]
+test = [
+	"pytest>=8",      # testing framework
+	"pytest-cov",     # test coverage
+	"pytest-mock",    # mocking
+	"pytest-timeout", # darn hanging tests
+]
+doc = [
+	"hydromt[examples,extra]",      # examples are included in the docs
+	"nbsphinx",                     # build notebooks in docs
+	"pydata-sphinx-theme>=0.15.2",  # theme
+	"sphinx_autosummary_accessors", # doc layout
+	"sphinx",                       # build docks
+	"sphinx_design",                # doc layout
+	"sphinx-click",                 # click integration
+	"sbom4python",                  # generate software bill of materials
+	"autodoc_pydantic",             # pydantic autodoc
+]
+examples = [
+	"cartopy",    # plotting examples
+	"jupyterlab", # run examples in jupyter notebook
+	"notebook",   # jupyter integration
+]
+slim = ["hydromt[io,extra,examples]"]
+
+[project.urls]
+Documentation = "https://deltares.github.io/hydromt"
+Source = "https://github.com/Deltares/hydromt"
+
+[project.scripts]
+hydromt = "hydromt.cli.main:main"
+
+[project.entry-points."hydromt.components"]
+core = "hydromt.model.components"
+
+[project.entry-points."hydromt.drivers"]
+core = "hydromt.data_catalog.drivers"
+
+[project.entry-points."hydromt.models"]
+core = "hydromt.model"
+
+[project.entry-points."hydromt.catalogs"]
+core = "hydromt.data_catalog.predefined_catalog"
+
+[project.entry-points."hydromt.uri_resolvers"]
+core = "hydromt.data_catalog.uri_resolvers"
+
+[tool.snakedown]
+
+api_content_path = "foo/"
+site_root = "bar"
+pkg_path = "hydromt"
+skip_undoc = true
+skip_private = false
+ssg = "Zola"
+exclude = []
+
+[tool.snakedown.externals]
+builtins = {name = "Python", url = "https://docs.python.org/3/"}
+
+[tool.snakedown.render.zola]
+use_shortcodes = true
+
+[tool.setuptools.dynamic]
+description = { file = "hydromt/__init__.py" }
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+exclude = ["docs", "hydromt/model/__init__.py"]
+
+[tool.ruff.lint]
+# enable pydocstyle (E), pyflake (F) and isort (I), pytest-style (PT), bugbear (B)
+select = ["E", "F", "I", "PT", "D", "B", "ICN", "TID"]
+ignore = ["D211", "D213", "D206", "E501", "E741", "D105", "E712", "B904"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["D100", "D101", "D102", "D103", "D104"]
+"hydromt/__init__.py" = ["E402", "F401", "F403"]
+"hydromt/models/__init__.py" = ["F401"]
+"hydromt/_compat.py" = ["F401"]
+"tests/conftest.py" = ["E402"]
+"examples/**" = ["B018", "D103"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.flit.sdist]
+include = ["hydromt"]
+exclude = ["docs", "examples", "envs", "tests", "binder", ".github"]
+
+[tool.pytest.ini_options]
+addopts = ["--ff", "-m", "not manual"]
+testpaths = ["tests"]
+markers = [
+	"integration: marks tests as being integration tests",
+	"manual: marks tests as manual, to be run before release",
+]
+
+filterwarnings = [
+	"error",
+	"ignore:numpy.ndarray size changed:RuntimeWarning",
+	# "ignore::rasterio.errors.NotGeoreferencedWarning",                              # upstream issue with rasterio, see https://github.com/rasterio/rasterio/issues/2497
+	"ignore:Detected a customized `__new__` method in subclass:DeprecationWarning", #upstream error in universal_pathlib see https://github.com/fsspec/universal_pathlib?tab=readme-ov-file#migrating-to-v020
+	"ignore::ResourceWarning",                                                      # upstream issue with aoihttp, can remove once aoihttp 4.0 is stable: https://github.com/aio-libs/aiohttp/issues/5426
+	"ignore::pytest.PytestUnraisableExceptionWarning",                              # combine with the above: https://github.com/pytest-dev/pytest/issues/9825
+	'ignore:pathlib\.Path\.__enter__:DeprecationWarning',                           # xugrid in python 3.11
+	#   "ignore:Implicit None on return values is deprecated and will raise KeyErrors:DeprecationWarning"
+	"ignore:__array_wrap__ must accept context and return_scalar arguments \\(positionally\\) in the future:DeprecationWarning",
+	'ignore:Python 3.14 will, by default, filter extracted tar archives:DeprecationWarning',                                     # pooch tarfile in python 3.12
+	"ignore:'mode' parameter is deprecated and will be removed in Pillow 13:DeprecationWarning",                                 # Pillow 13
+
+	# numpy itself silences these
+	# https://github.com/numpy/numpy/blob/46268caa719db95ab2198bcd619f0e3120d7c52e/numpy/__init__.py#L704-L707
+	"ignore:numpy.ndarray size changed:RuntimeWarning",
+
+	# zarr v3 experimental warning
+	"ignore:Consolidated metadata is currently not part in the Zarr format 3 specification:UserWarning",
+	# irrelevant radolan engine warning
+	"ignore:Engine 'radolan' loading failed.*:RuntimeWarning",
+]
+
+[tool.mypy]
+# TODO: Re-enable the tests
+exclude = ["docs/.*", "tests/.*"]
+plugins = ["pydantic.mypy", "numpy.typing.mypy_plugin"]
+python_version = "3.11"
+ignore_missing_imports = true
+
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+strict_equality = true
+extra_checks = true
+disallow_subclassing_any = true
+disallow_untyped_decorators = true
+disallow_any_generics = true
+
+[tool.pixi.workspace]
+channels = ["conda-forge"]
+platforms = ["linux-64", "win-64"]
+
+[tool.pixi.feature.py311.dependencies]
+python = "3.11.*"
+
+[tool.pixi.feature.py312.dependencies]
+python = "3.12.*"
+
+[tool.pixi.feature.py313.dependencies]
+python = "3.13.*"
+
+[tool.pixi.pypi-dependencies]
+hydromt = { path = ".", editable = true }
+
+[tool.pixi.feature.doc.dependencies]
+pandoc = "*"
+
+[tool.pixi.feature.io.dependencies]
+pyflwdir = ">=0.5.4"
+
+[tool.pixi.feature.vrt.dependencies]
+gdal = ">=3.5.0"
+
+[tool.pixi.feature.doc.tasks]
+doctest = { cmd = [
+	"sphinx-build",
+	"-M",
+	"doctest",
+	"docs",
+	"docs/_build",
+	"-W",
+] }
+docs-build = { cmd = [
+	"sphinx-build",
+	"-M",
+	"html",
+	"docs",
+	"docs/_build",
+	"-W",
+], depends-on = [
+	"doctest",
+] }
+docs-build-notest = { cmd = [
+	"sphinx-build",
+	"-M",
+	"html",
+	"docs",
+	"docs/_build",
+] }
+docs = { depends-on = ["docs-build"] } # alias
+doc = { depends-on = ["docs-build"] } # alias
+serve = { cmd = ["python", "-m", "http.server", "-d", "docs/_build/html"] }
+generate-sbom = { cmd = [
+	"sbom4python",
+	"--module",
+	"hydromt",
+	"--output-file",
+	"hydromt-core-sbom.json",
+	"--sbom",
+	"spdx",
+	"--format",
+	"json",
+] }
+
+[tool.pixi.feature.test.tasks]
+test = { cmd = ["pytest"] }
+test-lf = { cmd = ["pytest", "--lf", "--tb=short"] }
+test-err-warn = { cmd = ["pytest", "--tb=short", "-W", "error"] }
+test-cov = { cmd = [
+	"pytest",
+	"--verbose",
+	"--cov=hydromt",
+	"--cov-report=xml",
+	"--cov-branch",
+] }
+
+[tool.pixi.feature.dev.tasks]
+install = { depends-on = ["install-pre-commit"] }
+install-pre-commit = "pre-commit install"
+lint = { cmd = ["pre-commit", "run", "--all"] }
+mypy = "mypy ."
+
+pypi = { depends-on = [
+	"pypi-git-clean",
+	"pypi-git-restore",
+	"pypi-flit-build",
+	"pypi-twine",
+] }
+pypi-git-clean = { cmd = ["git", "clean", "-xdf"] }
+pypi-git-restore = { cmd = ["git", "restore", "-SW", "."] }
+pypi-flit-build = { cmd = ["flit", "build"] }
+pypi-twine = { cmd = ["python", "-m", "twine", "check", "dist/*"] }
+
+# clean
+clean = { depends-on = [
+	"clean-dist",
+	"clean-docs-generated",
+	"clean-docs-build",
+	"clean-docs-examples",
+] }
+clean-dist = { cmd = ["rm", "-rf", "dist"] }
+clean-docs-generated = { cmd = ["rm", "-rf", "docs/_generated"] }
+clean-docs-build = { cmd = ["rm", "-rf", "docs/_build"] }
+clean-docs-examples = { cmd = ["rm", "-rf", "docs/examples"] }
+
+[tool.pixi.environments]
+default = { features = [
+	"py311",
+	"io",
+	"vrt",
+	"extra",
+	"dev",
+	"test",
+	"doc",
+	"examples",
+], solve-group = "py311" }
+
+full-latest = { features = [
+	"py313",
+	"io",
+	"vrt",
+	"extra",
+	"dev",
+	"test",
+	"doc",
+	"examples",
+], solve-group = "py313" }
+min-latest = { features = ["py313", "test"], solve-group = "py313" }
+slim-latest = { features = [
+	"py313",
+	"io",
+	"vrt",
+	"extra",
+	"examples",
+], solve-group = "py313" }
+
+full-py313 = { features = [
+	"py313",
+	"io",
+	"vrt",
+	"extra",
+	"dev",
+	"test",
+	"doc",
+	"examples",
+], solve-group = "py313" }
+min-py313 = { features = ["py313", "test"], solve-group = "py313" }
+
+full-py312 = { features = [
+	"py312",
+	"io",
+	"vrt",
+	"extra",
+	"dev",
+	"test",
+	"doc",
+	"examples",
+], solve-group = "py312" }
+min-py312 = { features = ["py312", "test"], solve-group = "py312" }
+
+full-py311 = { features = [
+	"py311",
+	"io",
+	"vrt",
+	"extra",
+	"dev",
+	"test",
+	"doc",
+	"examples",
+], solve-group = "py311" }
+min-py311 = { features = ["py311", "test"], solve-group = "py311" }


### PR DESCRIPTION
Fixes #34 

It's quite common to put stuff like our config in a `pyproject.toml` so that users don't have to keep around way to many config files in their roor if they don't want too. This PR adds that possibility for snakedown as well. The testing on this PR is a little light because we use the well used `pyproject_toml` crate from the `pyo3` project to parse the toml file, and we use the exact same structs and merging logic as with `snakedown.toml` so I think it's okay to be a little looser here. 

For good measure I also grabbed the `pyproject.toml` from [hydromt](https://github.com/Deltares/hydromt) just because that is a fairly large `pyproject.toml` that I'm familiar with, and I wanted to have at least some dirty tests. 

The precedence now goes, from highest to lowest: cli args -> `snakedown.toml` -> `pyproject.toml` -> defaults
I may well add env variables at some point if there is a demand for that