### PR TITLE
fix: add content path to Renderer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,11 @@ pub fn render_docs<R: Renderer>(
     renderer: &R,
 ) -> Result<Vec<PathBuf>> {
     let absolute_pkg_path = pkg_path.canonicalize()?;
-    let out_path = site_root.join(api_content_path);
+    let out_path = if let Some(content_path) = renderer.content_path() {
+        site_root.join(content_path).join(api_content_path)
+    } else {
+        site_root.join(api_content_path)
+    };
     let errored = vec![];
 
     let mut ctx = Context::new();

--- a/src/render/formats/md.rs
+++ b/src/render/formats/md.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use color_eyre::Result;
 use url::Url;
@@ -41,6 +41,10 @@ impl Renderer for MdRenderer {
             None => format!("[{t}]({t})"),
         };
         Ok(rendered)
+    }
+
+    fn content_path(&self) -> Option<PathBuf> {
+        None
     }
 }
 

--- a/src/render/formats/mod.rs
+++ b/src/render/formats/mod.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use color_eyre::Result;
 
@@ -14,6 +14,11 @@ pub trait Renderer {
         target_prefix: &Path,
         target: String,
     ) -> Result<String>;
+
+    // This is on the Renderer because it is ssg specific.
+    // e.g. zola places content in the `content` folder at the site root
+    // but markdown places it just wherever it is pointed.
+    fn content_path(&self) -> Option<PathBuf>;
 }
 
 impl<T: Renderer + ?Sized> Renderer for &T {
@@ -32,6 +37,10 @@ impl<T: Renderer + ?Sized> Renderer for &T {
     fn render_front_matter(&self, title: Option<&str>) -> String {
         (**self).render_front_matter(title)
     }
+
+    fn content_path(&self) -> Option<PathBuf> {
+        (**self).content_path()
+    }
 }
 
 impl Renderer for Box<dyn Renderer> {
@@ -48,5 +57,8 @@ impl Renderer for Box<dyn Renderer> {
         target: String,
     ) -> Result<String> {
         (**self).render_reference(display_text, target_prefix, target)
+    }
+    fn content_path(&self) -> Option<PathBuf> {
+        (**self).content_path()
     }
 }

--- a/src/render/formats/zola.rs
+++ b/src/render/formats/zola.rs
@@ -47,6 +47,9 @@ impl Renderer for ZolaRenderer {
         };
         Ok(rendered)
     }
+    fn content_path(&self) -> Option<PathBuf> {
+        Some(PathBuf::from("content"))
+    }
 }
 
 #[cfg(test)]

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -37,7 +37,7 @@ fn test_cli_with_zola() -> Result<()> {
 
     let mut cmd = Command::cargo_bin("snakedown")?;
     cmd.arg("tests/test_pkg")
-        .arg(target_dir.join("content"))
+        .arg(&target_dir)
         .arg("--skip-undoc")
         .arg("--skip-private")
         .arg("-e")


### PR DESCRIPTION
Where an SSG expects it's content to be may differ but for ergonomics I
think it's better to give the root of the site. So this PR adds a
content_path() function to the Renderer as they should know where to
place them. I may find a better place for this eventually, but for now I
think it's okay.
