### PR TITLE
fix: add contributing.md to point to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+For our contributing guidelines please refer to the docs either [in the repo](/docs/src/contributing.md) or [online](https://savente93.github.io/snakedown/contributing.html)


### PR DESCRIPTION
Removed the CONTRIBUTING file when I moved that to the docs, but it's nice to have it in the root since github shows some buttons for it then, so I'll just add one that points people there. 