### PR TITLE
fix: add unknown sphinx std roles

### DIFF
--- a/snakedown.example.toml
+++ b/snakedown.example.toml
@@ -1,7 +1,7 @@
 api_content_path = "api/"
 site_root        = "docs"
 pkg_path         = "."
-skip_undoc       = true
+skip_undoc       = false
 skip_private     = false
 ssg              = "Markdown"
 exclude          = []

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,23 +68,23 @@ impl ConfigBuilder {
     pub fn init_with_defaults(mut self) -> Self {
         let mut externals = HashMap::new();
         externals.insert(
-            "numpy".to_string(),
-            ExternalIndex::new(
-                Some("Numpy".to_string()),
-                "https://numpy.org/doc/stable/".to_string(),
-            ),
-        );
-        externals.insert(
             "builtins".to_string(),
             ExternalIndex::new(
                 Some("Python".to_string()),
                 "https://docs.python.org/3/".to_string(),
             ),
         );
+        externals.insert(
+            "numpy".to_string(),
+            ExternalIndex::new(
+                Some("Numpy".to_string()),
+                "https://numpy.org/doc/stable/".to_string(),
+            ),
+        );
         self = self
             .with_site_root(Some(PathBuf::from("docs")))
             .with_api_content_path(Some(PathBuf::from("api/")))
-            .with_skip_undoc(Some(true))
+            .with_skip_undoc(Some(false))
             .with_skip_private(Some(false))
             .with_pkg_path(Some(PathBuf::from(".")))
             .with_exclude(Some(Vec::new()))

--- a/src/parsing/sphinx/types.rs
+++ b/src/parsing/sphinx/types.rs
@@ -58,11 +58,17 @@ impl TryFrom<&str> for SphinxType {
 }
 
 #[derive(Debug, PartialEq, EnumString)]
-#[strum(serialize_all = "camelCase")]
+#[strum(serialize_all = "kebab-case")]
 pub enum StdRole {
     Doc,
     Label,
     Term,
+    Cmdoption,
+    Pdbcommand,
+    Token,
+    Opcode,
+    MonitoringEvent,
+    Envvar,
 }
 #[derive(Debug, PartialEq, EnumString)]
 #[strum(serialize_all = "camelCase")]


### PR DESCRIPTION
Turns out I'd left a few std roles in the sphinx `objects.inv` undefined. This PR fixes that so we don't get parsing errors anymore even though we don't use them.