### PR TITLE
fix: add an index file to output if necessary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,13 @@ pub async fn render_docs(config: Config) -> Result<Vec<PathBuf>> {
         file.write_all(rendered_trimmed.as_bytes())?;
     }
 
+    if let Some((index_file_path, index_file_content)) =
+        &config.renderer.index_file(Some("API".to_string()))
+    {
+        let mut file = File::create(out_path.join(index_file_path))?;
+        file.write_all(index_file_content.as_bytes())?;
+    }
+
     Ok(errored)
 }
 

--- a/src/render/formats/md.rs
+++ b/src/render/formats/md.rs
@@ -46,6 +46,10 @@ impl Renderer for MdRenderer {
     fn content_path(&self) -> Option<PathBuf> {
         None
     }
+
+    fn index_file(&self, _title: Option<String>) -> Option<(PathBuf, String)> {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/src/render/formats/mod.rs
+++ b/src/render/formats/mod.rs
@@ -19,6 +19,8 @@ pub trait Renderer {
     // e.g. zola places content in the `content` folder at the site root
     // but markdown places it just wherever it is pointed.
     fn content_path(&self) -> Option<PathBuf>;
+
+    fn index_file(&self, title: Option<String>) -> Option<(PathBuf, String)>;
 }
 
 impl<T: Renderer + ?Sized> Renderer for &T {
@@ -41,6 +43,9 @@ impl<T: Renderer + ?Sized> Renderer for &T {
     fn content_path(&self) -> Option<PathBuf> {
         (**self).content_path()
     }
+    fn index_file(&self, title: Option<String>) -> Option<(PathBuf, String)> {
+        (**self).index_file(title)
+    }
 }
 
 impl Renderer for Box<dyn Renderer> {
@@ -60,5 +65,8 @@ impl Renderer for Box<dyn Renderer> {
     }
     fn content_path(&self) -> Option<PathBuf> {
         (**self).content_path()
+    }
+    fn index_file(&self, title: Option<String>) -> Option<(PathBuf, String)> {
+        (**self).index_file(title)
     }
 }

--- a/src/render/formats/zola.rs
+++ b/src/render/formats/zola.rs
@@ -50,6 +50,12 @@ impl Renderer for ZolaRenderer {
     fn content_path(&self) -> Option<PathBuf> {
         Some(PathBuf::from("content"))
     }
+
+    fn index_file(&self, title: Option<String>) -> Option<(PathBuf, String)> {
+        let index_front_matter = self.render_front_matter(title.as_deref());
+
+        Some((PathBuf::from("_index.md"), index_front_matter))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
in Zola, the output will need an `_index.md` file to be considered a section, and I'd like the output to just be runnable out of the box, so I'm adding some functionality to renders to render an index file if necessary. Renderers like plain markdown do not need this, so they return Options