### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,73 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.2.0](https://github.com/savente93/snakedown/compare/v0.1.0...v0.2.0) - 2026-01-11
+
+### Added
+
+- enable expansion of external references
+- add GHA to deploy book
+- fill out user guide
+- add an mdbook for documentation
+- add ability to read config from pyproject
+- first impl of internal linking
+- add comment about implementation strategy
+- implement ref checking for fully qualified refs
+- add internal links to docstrings in test pkg
+- use tera to render page templates
+- add tera as dependency
+- refactor indexing logic
+- add general python object docs enum
+- move to flat output structure
+- add python builting as external default example
+- implment passing links to external inventory
+- implement passing optoins to renderers from config
+- implement internal link rendering
+- implement external link rendering
+- allow config file passed through cli
+- implement merging for config builders
+- impl config builder pattern
+- implement basic object.inv fetching and caching
+- hand implement sphinx ref parsing
+- implement sphinx inventory header parsing
+
+### Fixed
+
+- remove unused dependendies
+- justfile zola build command
+- add an index file to output if necessary
+- add unknown sphinx std roles
+- add contributing.md to point to docs
+- taplo lint
+- make render_docs async
+- add content path to Renderer
+- add mdbook to test
+- add doc to just file ci command
+- replace local zola site with git submodule
+- make generated links relative to site root
+- move prefix stripping from rendering to parsing
+- fix oder of compare_tree
+- remove prefix from docs extraction to rendering
+- remove sub_package_index from pakcage index struct
+- move indexing/{cache,fetch}.rs to their own mod
+- ignore snakedown cache in repo
+- fix just zola command
+- expand sphinx shorthands
+- fetch correct objects.inv
+- run fetching external obj as async
+
+### Other
+
+- sort cargo.toml
+- update zola testsite submodule
+- refactor render_docs api
+- add Contributing guidelines
+- *(deps)* bump actions/checkout from 5 to 6
+- *(deps)* bump toml_edit from 0.22.26 to 0.23.2
+- add .bacon-locations to .gitignore
+- *(deps)* bump actions/checkout from 4 to 5
+- add badges to readme
+
 
 ### ✨ Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2097,7 +2097,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snakedown"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "snakedown"
-version      = "0.1.0"
+version      = "0.2.0"
 authors      = ["Sam Vente <savente93@proton.me>"]
 edition      = "2024"
 rust-version = "1.91"


### PR DESCRIPTION



## 🤖 New release

* `snakedown`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `snakedown` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_missing.ron

Failed in:
  function snakedown::fs::get_python_prefix, previously in file /tmp/.tmpSf8Vjd/snakedown/src/fs.rs:41

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_parameter_count_changed.ron

Failed in:
  snakedown::render::render_module now takes 4 parameters instead of 2, in /tmp/.tmpxyOFrT/snakedown/src/render/mod.rs:91
  snakedown::render_module now takes 4 parameters instead of 2, in /tmp/.tmpxyOFrT/snakedown/src/render/mod.rs:91
  snakedown::render_docs now takes 1 parameters instead of 6, in /tmp/.tmpxyOFrT/snakedown/src/lib.rs:29

--- failure function_requires_different_generic_type_params: function now requires a different number of generic type parameters ---

Description:
A function now requires a different number of generic type parameters than it used to. Uses of this function that supplied the previous number of generic types (e.g. via turbofish syntax) will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_requires_different_generic_type_params.ron

Failed in:
  function render_docs (1 -> 0 generic types) in /tmp/.tmpxyOFrT/snakedown/src/lib.rs:29

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/inherent_method_missing.ron

Failed in:
  ZolaRenderer::new, previously in file /tmp/.tmpSf8Vjd/snakedown/src/render/formats/zola.rs:11

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field sub_module_index of struct PackageIndex, previously in file /tmp/.tmpSf8Vjd/snakedown/src/fs.rs:213

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_method_added.ron

Failed in:
  trait method snakedown::render::formats::Renderer::render_reference in file /tmp/.tmpxyOFrT/snakedown/src/render/formats/mod.rs:11
  trait method snakedown::render::formats::Renderer::content_path in file /tmp/.tmpxyOFrT/snakedown/src/render/formats/mod.rs:21
  trait method snakedown::render::formats::Renderer::index_file in file /tmp/.tmpxyOFrT/snakedown/src/render/formats/mod.rs:23
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/savente93/snakedown/compare/v0.1.0...v0.2.0) - 2026-01-11

### Added

- enable expansion of external references
- add GHA to deploy book
- fill out user guide
- add an mdbook for documentation
- add ability to read config from pyproject
- first impl of internal linking
- add comment about implementation strategy
- implement ref checking for fully qualified refs
- add internal links to docstrings in test pkg
- use tera to render page templates
- add tera as dependency
- refactor indexing logic
- add general python object docs enum
- move to flat output structure
- add python builting as external default example
- implment passing links to external inventory
- implement passing optoins to renderers from config
- implement internal link rendering
- implement external link rendering
- allow config file passed through cli
- implement merging for config builders
- impl config builder pattern
- implement basic object.inv fetching and caching
- hand implement sphinx ref parsing
- implement sphinx inventory header parsing

### Fixed

- remove unused dependendies
- justfile zola build command
- add an index file to output if necessary
- add unknown sphinx std roles
- add contributing.md to point to docs
- taplo lint
- make render_docs async
- add content path to Renderer
- add mdbook to test
- add doc to just file ci command
- replace local zola site with git submodule
- make generated links relative to site root
- move prefix stripping from rendering to parsing
- fix oder of compare_tree
- remove prefix from docs extraction to rendering
- remove sub_package_index from pakcage index struct
- move indexing/{cache,fetch}.rs to their own mod
- ignore snakedown cache in repo
- fix just zola command
- expand sphinx shorthands
- fetch correct objects.inv
- run fetching external obj as async

### Other

- sort cargo.toml
- update zola testsite submodule
- refactor render_docs api
- add Contributing guidelines
- *(deps)* bump actions/checkout from 5 to 6
- *(deps)* bump toml_edit from 0.22.26 to 0.23.2
- add .bacon-locations to .gitignore
- *(deps)* bump actions/checkout from 4 to 5
- add badges to readme


### ✨ Features

- Add doc and coverage just commands
- Detect on disk python modules
- Index ondisk python package
- Extract python documentation from ASTs
- Add dirty test package for integration test
- Add expression rendering skeleton
- Implement tuple rendering
- Implement list rendering
- Impl operator rendreing
- Impl dict & list comprehension rendering
- Impl call rendering
- Impl slice and subscript render
- Impl attribute rendering
- Increase rendering test coverage
- Impl doc rendering
- Impl remaining expression rendering
- Add rendered versions of test_pkg for testing
- Impl rendering of docs from full fs trees
- Impl a cli
- Add option to explicitly exclude files
- Add more granular logging (#2)
- Impl documenting exported attrs in modules (#3)
- Add submodule index to rendered output (#4)
- Add just cmd to open pr if ci locally passes (#5)
- Implement more general front matter rendering
- Add cli option for selecting ssg format
- Add minimal zola test site
- Impl zola front matter rendering
- Add zola installation in ci (#8)
- Add just cmd to build zola test site
- Implement generic rendering trait (#27)
- Add release-plz config

### 📖 Documentation

- Add roadmap to README
- Add description to README

### 🛠️ Maintenance

- Put separate doc types in their own mod
- Disable patch coverage (#6)
- Add zola integration test

### 🤕 Fixes

- Move doctests to module to increase coverage
- Incorrect upper case in boolean rendering
- Add space around bin op in rendering
- Remove dbg statements and add pre-commit hook (#7)
- Check tree is clean before opening pr (#9)
- Update description of cli exclude option (#10)
- Codecov format was incorrect (#11)
- Rename to snakedown
- Deprecate commitlintrc in favour of committed (#13)
- Add custom anchor render for zola headers
- Don't create extra dir at output path
- Remove syntax_error.py from output (#24)
- Revert rendering of submodules and exports (#25)

<!-- generated by git-cliff -->
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).