### PR TITLE
feat: introduce negative flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 use color_eyre::eyre::Result;
-use snakedown::render_docs;
+use snakedown::{config::ConfigBuilder, render_docs};
 use tracing::subscriber::set_global_default;
 
 mod cli;
 
-use crate::cli::{Args, resolve_runtime_config};
+use crate::cli::{CliArgs, resolve_runtime_config};
 use clap::Parser;
 
 #[allow(clippy::missing_errors_doc)]
@@ -12,7 +12,7 @@ use clap::Parser;
 async fn main() -> Result<()> {
     color_eyre::install()?;
 
-    let args = Args::parse();
+    let args = CliArgs::parse();
     let subscriber = tracing_subscriber::fmt()
         .with_max_level(args.verbose.tracing_level_filter())
         .finish();
@@ -20,9 +20,10 @@ async fn main() -> Result<()> {
     set_global_default(subscriber)?;
 
     tracing::debug_span!("resolving runtime config");
-    let config = resolve_runtime_config(args)?;
+    let default_config = ConfigBuilder::default().init_with_defaults();
+    let runtime_config = resolve_runtime_config(args)?;
 
-    tracing::debug!("fetching external indices");
+    let config = default_config.merge(runtime_config).build()?;
 
     render_docs(config).await?;
 


### PR DESCRIPTION
examples are --skip-undoc and --no-skip-undoc. currently for example if
you set in your config file that skip_undoc is true there is no way to
turn it back off in the cli, which is a bit awkward. This fixes that.
