### PR TITLE
fix: add spelling and committed checks to ci

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,3 +29,24 @@ jobs:
 
       - name: run lints
         run: pixi run lint
+  committed:
+    name: Lint Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+      - name: dump commit messages
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          TAG="$(git tag | sort -V -r | head -n 1)"
+          git log "$TAG"..HEAD --format=%B > msg.txt
+
+      - name: Check spelling of commit messages
+        uses: crate-ci/typos@v1.42.1
+        with:
+          files: ./msg.txt
+      - name: Check conventional commits
+        uses: crate-ci/committed@master


### PR DESCRIPTION
 

## Explanation


There was a typo in the commit history that was causing some trouble for release CIs etc, but it was behind a commit that was already released, so I had to slightly rewrite history to fix that. THis PR adds some lints to make sure the commit messages are well formatted and relatively typo free. 

## General Checklist

- [ ] Updated tests or added new tests (if applicable)
- [ ] Branch is up to date with `main`
- [ ] Tests & lints hooks pass
- [ ] Updated documentation (if applicable)
- [ ] History of branch is cleaned up

