### PR TITLE
feat: add windows support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,11 @@ concurrency:
 name: test
 jobs:
   required:
-    runs-on: ubuntu-latest
-    name: suite
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    name: suite (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v6
         with:

--- a/src/render/formats/zola.rs
+++ b/src/render/formats/zola.rs
@@ -88,13 +88,18 @@ mod test {
 
     #[test]
     fn zola_internal_link_no_shortcode() -> Result<()> {
+        #[cfg(windows)]
+        let expected = r#"[Baz](@\foo.bar.baz.index.md)"#;
+        #[cfg(not(windows))]
+        let expected = r#"[Baz](@/foo.bar.baz.index.md)"#;
+
         assert_eq!(
             ZolaRenderer {}.render_reference(
                 Some("Baz".to_string()),
                 &PathBuf::from(""),
-                String::from("foo/bar/baz/index")
+                String::from("foo.bar.baz.index")
             )?,
-            r#"[Baz](@/foo/bar/baz/index.md)"#
+            expected
         );
         Ok(())
     }


### PR DESCRIPTION
## Issue addressed

Fixes #86 

## Explanation

Some small modifications were necessary becomes of line endings. It's a little hacky but we just strip both `\r` from the output at the moment, and had to manually implement a recursive copy.. This also enabled running the tests in windows on CI.

## General Checklist

- [x] Updated tests or added new tests (if applicable)
- [x] Branch is up to date with `main`
- [x] Tests & lints hooks pass
- [x] Updated documentation (if applicable)
- [x] History of branch is cleaned up

