### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.3.1](https://github.com/savente93/snakedown/compare/v0.3.0...v0.3.1) - 2026-03-23
+
+### Fixed
+
+- non existent pandas link in 404 fetch test
+- add linking arg for flamegraph
+- abort on HTTP error when fetching cache
+
 ## [0.3.0](https://github.com/savente93/snakedown/compare/v0.2.0...v0.3.0) - 2026-02-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,7 +2387,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snakedown"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "snakedown"
-version      = "0.3.0"
+version      = "0.3.1"
 authors      = ["Sam Vente <savente93@proton.me>"]
 edition      = "2024"
 rust-version = "1.91"


### PR DESCRIPTION



## 🤖 New release

* `snakedown`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/savente93/snakedown/compare/v0.3.0...v0.3.1) - 2026-03-23

### Fixed

- non existent pandas link in 404 fetch test
- add linking arg for flamegraph
- abort on HTTP error when fetching cache
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).