### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.3.1](https://github.com/savente93/snakedown/compare/v0.3.0...v0.3.1) - 2026-04-07
+
+### Fixed
+
+- non existent pandas link in 404 fetch test
+- add linking arg for flamegraph
+- abort on HTTP error when fetching cache
+
+### Other
+
+- *(deps)* bump codecov/codecov-action from 5 to 6
+- *(deps)* bump prefix-dev/setup-pixi from 0.9.4 to 0.9.5
+
 ## [0.3.0](https://github.com/savente93/snakedown/compare/v0.2.0...v0.3.0) - 2026-02-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,7 +2387,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "snakedown"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "snakedown"
-version      = "0.3.0"
+version      = "0.3.1"
 authors      = ["Sam Vente <savente93@proton.me>"]
 edition      = "2024"
 rust-version = "1.91"


### PR DESCRIPTION



## 🤖 New release

* `snakedown`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `snakedown` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum snakedown::parsing::sphinx::types::SphinxPriority, previously in file /tmp/.tmpdCo5aK/snakedown/src/parsing/sphinx/types.rs:8
  enum snakedown::parsing::sphinx::types::StdRole, previously in file /tmp/.tmpdCo5aK/snakedown/src/parsing/sphinx/types.rs:62
  enum snakedown::parsing::sphinx::types::CRole, previously in file /tmp/.tmpdCo5aK/snakedown/src/parsing/sphinx/types.rs:75
  enum snakedown::parsing::sphinx::types::PyRole, previously in file /tmp/.tmpdCo5aK/snakedown/src/parsing/sphinx/types.rs:112
  enum snakedown::parsing::sphinx::types::CppRole, previously in file /tmp/.tmpdCo5aK/snakedown/src/parsing/sphinx/types.rs:89
  enum snakedown::parsing::sphinx::types::SphinxType, previously in file /tmp/.tmpdCo5aK/snakedown/src/parsing/sphinx/types.rs:30
  enum snakedown::parsing::sphinx::types::JsRole, previously in file /tmp/.tmpdCo5aK/snakedown/src/parsing/sphinx/types.rs:98
  enum snakedown::parsing::sphinx::types::MathRole, previously in file /tmp/.tmpdCo5aK/snakedown/src/parsing/sphinx/types.rs:107
  enum snakedown::parsing::sphinx::inv_file::SphinxInvVersion, previously in file /tmp/.tmpdCo5aK/snakedown/src/parsing/sphinx/inv_file.rs:13
  enum snakedown::parsing::sphinx::types::RstRole, previously in file /tmp/.tmpdCo5aK/snakedown/src/parsing/sphinx/types.rs:124

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function snakedown::parsing::sphinx::inv_file::parse_objects_inv_file, previously in file /tmp/.tmpdCo5aK/snakedown/src/parsing/sphinx/inv_file.rs:98
  function snakedown::parsing::sphinx::inv_file::parse_objects_inv, previously in file /tmp/.tmpdCo5aK/snakedown/src/parsing/sphinx/inv_file.rs:83

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod snakedown::parsing::sphinx, previously in file /tmp/.tmpdCo5aK/snakedown/src/parsing/sphinx/mod.rs:1
  mod snakedown::parsing::sphinx::inv_file, previously in file /tmp/.tmpdCo5aK/snakedown/src/parsing/sphinx/inv_file.rs:1
  mod snakedown::parsing::sphinx::types, previously in file /tmp/.tmpdCo5aK/snakedown/src/parsing/sphinx/types.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct snakedown::parsing::sphinx::types::ExternalSphinxRef, previously in file /tmp/.tmpdCo5aK/snakedown/src/parsing/sphinx/types.rs:127
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/aslowwriter/snakedown/compare/v0.3.0...v0.4.0) - 2026-08-15

### Fixed

- fix breaking changes introduced in nbformat 3
- update github handle
- non existent pandas link in 404 fetch test
- add linking arg for flamegraph
- abort on HTTP error when fetching cache

### Other

- *(deps)* bump prefix-dev/setup-pixi from 0.10.0 to 0.10.1
- *(deps)* bump tera from 1.20.1 to 2.1.0
- add contrib guideines about adding ssgs
- *(deps)* bump prefix-dev/setup-pixi from 0.9.6 to 0.10.0
- *(deps)* bump actions/checkout from 6 to 7
- *(deps)* bump codecov/codecov-action from 6 to 7
- *(deps)* bump prefix-dev/setup-pixi from 0.9.5 to 0.9.6
- move to sphinx_inv for inv parsing
- *(deps)* bump codecov/codecov-action from 5 to 6
- *(deps)* bump prefix-dev/setup-pixi from 0.9.4 to 0.9.5
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).